### PR TITLE
Make discord bot be able to run on the new infrastructure with the new mikero PBO's

### DIFF
--- a/lib/ftp-upload.js
+++ b/lib/ftp-upload.js
@@ -34,6 +34,7 @@ exports.uploadPbo = (pboFilepath, wantedUploadName, callback) => {
   const sftp = new SftpClient();
   sftp.connect({
     host: process.env.FTP_HOST,
+    port: process.env.FTP_PORT,
     user: process.env.FTP_USER,
     password: process.env.FTP_PASSWORD
   })

--- a/lib/pbo-tools.js
+++ b/lib/pbo-tools.js
@@ -34,7 +34,7 @@ exports.lintPboFolder = (folderPath, callback) => {
       return callback(err);
     }
 
-    const command = `makepbo -PQ ${folderPath} bla.pbo`;
+    const command = `makepbo -W ${folderPath} bla.pbo`;
     child_process.exec(command, (err, stdout, stderr) => {
       if (!err) return callback(null, {ok: true});
 


### PR DESCRIPTION
The -W parameter treats warnings as errors. If it gets too annoying, it can be removed.

Validating of a pbo takes ~10 seconds. Don't know why.