### PR TITLE
Changed example url to a guaranteed invalid one as per RFC 2606

### DIFF
--- a/lib/commands/upload.ts
+++ b/lib/commands/upload.ts
@@ -23,7 +23,7 @@ export class UploadCommand implements Command {
   private log = LoggerFactory.create(UploadCommand)
   readonly type = '!upload'
   readonly usageInfo =
-    'Uploads a pbo to the server. Usage: !upload (repo) (url) (optional: wanted pbo name. MUST INCLUDE WORLD). Example: !upload main http://www.dl.com/test.pbo tvt30_terry.tanoa'
+    'Uploads a pbo to the server. Usage: !upload (repo) (url) (optional: wanted pbo name. MUST INCLUDE WORLD). Example: !upload main http://www.domain.invalid/test.pbo tvt30_terry.tanoa'
   readonly rateLimit = 20
   readonly onlyMods = false
 


### PR DESCRIPTION
This avoids discord showing a preview of dl.com when a user uses the help command.