### PR TITLE
Case insensitive find user by name

### DIFF
--- a/src/services/fp_db/fp_db_client.rs
+++ b/src/services/fp_db/fp_db_client.rs
@@ -28,7 +28,7 @@ impl FpDbClient {
         let collection = db.collection::<User>("users");
         let filter = doc! {
             "$or": [
-                { "name": username_or_steam_id },
+                { "name": "/{username_or_steam_id}$/i" },
                 { "steam_id": username_or_steam_id }
             ]
         };


### PR DESCRIPTION
i am making this out of spite

I have no idea if that's how the syntax actually works and i'm not about to wait until I learn rust to add a case insensitive regex flag

from what I gather ideally the db itself would be set up so you can look these up in a case insensitive manner, maybe in 2035 when we actually get website v2